### PR TITLE
Fix NuGet upload job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -104,4 +104,5 @@ jobs:
           dotnet nuget push
           dist/*.nupkg
           --skip-duplicate
+          --source https://api.nuget.org/v3/index.json
           --api-key ${{ secrets.NUGET_API_KEY }}

--- a/Assemblies/Http/TixFactory.Http.Server/TixFactory.Http.Server.csproj
+++ b/Assemblies/Http/TixFactory.Http.Server/TixFactory.Http.Server.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageTags>http server</PackageTags>
   </PropertyGroup>

--- a/Assemblies/NuGet.config
+++ b/Assemblies/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <config>
-    <add key="defaultPushSource" value="https://api.nuget.org/v3/index.json"/>
-  </config>
-</configuration>


### PR DESCRIPTION
Two problems:
- `TixFactory.Http.Server` wasn't actually being packed, because the `Microsoft.NET.Sdk.Web` SDK defaulted `IsPackable` to `false`
- `NuGet.config` wasn't in the working directory, because we didn't clone it, so the `defaultPushSource` wasn't actually available.