### PR TITLE
Add prometheus to TixFactory.Http.Service

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Directory.Packages.props
+++ b/Assemblies/Directory.Packages.props
@@ -15,5 +15,6 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Converters;
 using Prometheus;
+using Prometheus.HttpMetrics;
 using TixFactory.ApplicationContext;
 
 namespace TixFactory.Http.Service;
@@ -27,6 +28,7 @@ public abstract class Startup
     {
         app.UseMiddleware<UnhandledExceptionMiddleware>();
         app.UseRouting();
+        app.UseHttpMetrics(ConfigureMetrics);
         app.UseEndpoints(ConfigureEndpoints);
     }
 
@@ -80,5 +82,13 @@ public abstract class Startup
     protected virtual void ConfigureLogging(ILoggingBuilder loggingBuilder)
     {
         loggingBuilder.AddConsoleFormatter<ServiceLoggingFormatter, ServiceLoggingFormatterOptions>();
+    }
+
+    /// <summary>
+    /// Configure HTTP metrics exported to prometheus.
+    /// </summary>
+    /// <param name="options">The <see cref="HttpMiddlewareExporterOptions"/>.</param>
+    protected virtual void ConfigureMetrics(HttpMiddlewareExporterOptions options)
+    {
     }
 }

--- a/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Converters;
+using Prometheus;
 using TixFactory.ApplicationContext;
 
 namespace TixFactory.Http.Service;
@@ -68,6 +69,7 @@ public abstract class Startup
     /// <param name="endpointRouteBuilder">The <see cref="IEndpointRouteBuilder"/>.</param>
     protected virtual void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder)
     {
+        endpointRouteBuilder.MapMetrics();
         endpointRouteBuilder.MapControllers();
     }
 

--- a/Assemblies/Http/TixFactory.Http.Service/TixFactory.Http.Service.csproj
+++ b/Assemblies/Http/TixFactory.Http.Service/TixFactory.Http.Service.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ApplicationContext\TixFactory.ApplicationContext\TixFactory.ApplicationContext.csproj" />


### PR DESCRIPTION
# What

Adding support to `TixFactory.Http.Service` to expose prometheus metrics via [prometheus-net.AspNetCore](https://github.com/prometheus-net/prometheus-net#aspnet-core-http-request-metrics).