### PR TITLE
Fix UpdateOneAsync

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.6.0</VersionPrefix>
+    <VersionPrefix>3.6.1</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Http/TixFactory.Http.Service/Implementation/ServiceLoggingFormatter.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Implementation/ServiceLoggingFormatter.cs
@@ -75,8 +75,12 @@ public class ServiceLoggingFormatter : ConsoleFormatter, IDisposable
                 serializableLog.ExceptionMessage = logEntry.Exception.Message;
             }
 
-            serializableLog.SerializedException = logEntry.Exception.ToString();
-            serializableLog.ExceptionType = logEntry.Exception.GetType().FullName;
+            var exceptionType = logEntry.Exception.GetType().FullName ?? string.Empty;
+            serializableLog.ExceptionType = exceptionType;
+
+            var serializedException = logEntry.Exception.ToString();
+            var stackTraceStartIndex = exceptionType.Length + logEntry.Exception.Message.Length + 2;
+            serializableLog.ExceptionStackTrace = serializedException.Length > stackTraceStartIndex ? serializedException[stackTraceStartIndex..].Trim() : serializedException;
         }
 
         if (!string.IsNullOrWhiteSpace(logEntry.Category))

--- a/Assemblies/Http/TixFactory.Http.Service/Models/ServiceLog.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Models/ServiceLog.cs
@@ -64,7 +64,7 @@ internal class ServiceLog
     /// https://www.elastic.co/guide/en/ecs/current/ecs-error.html#field-error-stack-trace
     /// </remarks>
     [DataMember(Name = "error.stack_trace", EmitDefaultValue = false)]
-    public string SerializedException { get; set; }
+    public string ExceptionStackTrace { get; set; }
 
     /// <summary>
     /// When the log was logged.

--- a/Assemblies/MongoDB/TixFactory.MongoDB/CollectionExtensions.cs
+++ b/Assemblies/MongoDB/TixFactory.MongoDB/CollectionExtensions.cs
@@ -82,7 +82,7 @@ public static class CollectionExtensions
                 Comment = WriteComment
             }, cancellationToken);
 
-            if (result != null)
+            if (result.ModifiedCount != 1)
             {
                 throw new MongoException($"Expected exactly one document to be updated, but got {result.ModifiedCount}");
             }


### PR DESCRIPTION
# What

It's broken, because of course it is. LOOK AT IT. :eyes:

# Unrelated

I also improved `error.stack_trace` property for logging, cutting out the `error.message` + `error.type`.