### PR TITLE
Fix bug in HttpClient

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.7.1</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Http/TixFactory.Http.Client/Handlers/SendHttpRequestHandler.cs
+++ b/Assemblies/Http/TixFactory.Http.Client/Handlers/SendHttpRequestHandler.cs
@@ -197,8 +197,11 @@ namespace TixFactory.Http.Client
 
         private (System.Net.Http.HttpClient HttpClient, HttpClientHandler Handler) CreateHttpClient()
         {
-            var httpClientHandler = new HttpClientHandler();
-            httpClientHandler.AllowAutoRedirect = _HttpClientSettings.MaxRedirects > 0;
+            var httpClientHandler = new HttpClientHandler
+            {
+                CookieContainer = _CookieContainer,
+                AllowAutoRedirect = _HttpClientSettings.MaxRedirects > 0
+            };
 
             if (httpClientHandler.AllowAutoRedirect)
             {


### PR DESCRIPTION
Right now, if we send an HTTP request with `TixFactory.Http.Client`, the second request will fail, because it will attempt to use the setter on the `HttpClientHandler`, which can't happen after the first request has been sent.

We'll recreate the client when this happens.