### PR TITLE
Fix HTTP server metrics for unhandled exceptions

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.7.2</VersionPrefix>
+    <VersionPrefix>3.7.3</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
@@ -28,9 +28,9 @@ public abstract class Startup
     /// <param name="env">The <see cref="IHostingEnvironment"/>.</param>
     public virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
-        app.UseMiddleware<UnhandledExceptionMiddleware>();
         app.UseRouting();
         app.UseHttpMetrics(ConfigureMetrics);
+        app.UseMiddleware<UnhandledExceptionMiddleware>();
         app.UseEndpoints(ConfigureEndpoints);
     }
 


### PR DESCRIPTION
# What

Right now unhandled exceptions are being treated by prometheus metrics as if they were successful. This is probably because the handler to turn that response into a 500 happens after the metrics have been recorded. Moving this middleware to after the HTTP metrics call should fix this.