### PR TITLE
Replace Configure method in Startup

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
@@ -28,7 +28,7 @@ public abstract class Startup
     /// You must call this from the Configure method on startup.
     /// </remarks>
     /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
-    public void UseConfiguration(IApplicationBuilder app)
+    protected void UseConfiguration(IApplicationBuilder app)
     {
         app.UseRouting();
         app.UseHttpMetrics(ConfigureMetrics);

--- a/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
+++ b/Assemblies/Http/TixFactory.Http.Service/Implementation/Startup.cs
@@ -24,9 +24,11 @@ public abstract class Startup
     /// <summary>
     /// Configures the <see cref="IApplicationBuilder"/> for the application.
     /// </summary>
+    /// <remarks>
+    /// You must call this from the Configure method on startup.
+    /// </remarks>
     /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
-    /// <param name="env">The <see cref="IHostingEnvironment"/>.</param>
-    public virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    public void UseConfiguration(IApplicationBuilder app)
     {
         app.UseRouting();
         app.UseHttpMetrics(ConfigureMetrics);


### PR DESCRIPTION
Need to be able to inject custom classes to the `Configure` method, so this has to become something else. How about `UseConfiguration`? :shrug: