### PR TITLE
Fix security issue with TixFactory.CookieJar

### DIFF
--- a/Assemblies/CookieJar/TixFactory.CookieJar/Implementation/FileCookieJar.cs
+++ b/Assemblies/CookieJar/TixFactory.CookieJar/Implementation/FileCookieJar.cs
@@ -1,8 +1,8 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
+using Newtonsoft.Json;
 
 namespace TixFactory.CookieJar
 {
@@ -13,8 +13,7 @@ namespace TixFactory.CookieJar
     public class FileCookieJar : ICookieJar
     {
         private readonly string _FileName;
-        private readonly BinaryFormatter _BinaryFormatter;
-        private readonly SemaphoreSlim _SaveLock = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _SaveLock = new(1, 1);
 
         /// <inheritdoc cref="ICookieJar.CookieContainer"/>
         public CookieContainer CookieContainer { get; }
@@ -22,14 +21,12 @@ namespace TixFactory.CookieJar
         /// <summary>
         /// Initializes a new <see cref="FileCookieJar"/>.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="cookieContainer"/> is set, any cookies in the file are ignored, and replaced.
+        /// </remarks>
         /// <param name="fileName">The file name to save/load the cookies to/from.</param>
-        /// <param name="cookieContainer"></param>
+        /// <param name="cookieContainer">An initial <see cref="CookieContainer"/>.</param>
         public FileCookieJar(string fileName, CookieContainer cookieContainer = null)
-            : this(new BinaryFormatter(), fileName, cookieContainer)
-        {
-        }
-
-        private FileCookieJar(BinaryFormatter binaryFormatter, string fileName, CookieContainer cookieContainer = null)
         {
             if (string.IsNullOrWhiteSpace(fileName))
             {
@@ -37,8 +34,7 @@ namespace TixFactory.CookieJar
             }
 
             _FileName = fileName;
-            _BinaryFormatter = binaryFormatter ?? throw new ArgumentNullException(nameof(binaryFormatter));
-            CookieContainer = cookieContainer ?? CreateCookieContainer(fileName, binaryFormatter);
+            CookieContainer = cookieContainer ?? CreateCookieContainer(fileName);
         }
 
         /// <inheritdoc cref="ICookieJar.Save"/>
@@ -53,11 +49,8 @@ namespace TixFactory.CookieJar
 
             try
             {
-                using (var memoryStream = new MemoryStream())
-                {
-                    _BinaryFormatter.Serialize(memoryStream, CookieContainer);
-                    File.WriteAllBytes(_FileName, memoryStream.ToArray());
-                }
+                var cookies = JsonConvert.SerializeObject(CookieContainer.GetAllCookies());
+                File.WriteAllText(_FileName, cookies);
             }
             finally
             {
@@ -65,18 +58,22 @@ namespace TixFactory.CookieJar
             }
         }
 
-        private static CookieContainer CreateCookieContainer(string fileName, BinaryFormatter binaryFormatter)
+        private static CookieContainer CreateCookieContainer(string fileName)
         {
-            if (File.Exists(fileName))
+            var cookieContainer = new CookieContainer();
+
+            try
             {
-                var cookieBytes = File.ReadAllBytes(fileName);
-                using (var memoryStream = new MemoryStream(cookieBytes))
-                {
-                    return (CookieContainer)binaryFormatter.Deserialize(memoryStream);
-                }
+                var cookies = File.ReadAllText(fileName);
+                var cookieCollection = JsonConvert.DeserializeObject<CookieCollection>(cookies);
+                cookieContainer.Add(cookieCollection);
+            }
+            catch
+            {
+                // Probably shouldn't swallow this. ¯\_(ツ)_/¯
             }
 
-            return new CookieContainer();
+            return cookieContainer;
         }
     }
 }

--- a/Assemblies/CookieJar/TixFactory.CookieJar/TixFactory.CookieJar.csproj
+++ b/Assemblies/CookieJar/TixFactory.CookieJar/TixFactory.CookieJar.csproj
@@ -1,5 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <OutputType>Library</OutputType>
     <TargetFramework>net6</TargetFramework>
     <PackageTags>http</PackageTags>
   </PropertyGroup>

--- a/Assemblies/CookieJar/TixFactory.CookieJar/TixFactory.CookieJar.csproj
+++ b/Assemblies/CookieJar/TixFactory.CookieJar/TixFactory.CookieJar.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <PackageTags>http</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
 </Project>

--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.9.0</VersionPrefix>
+    <VersionPrefix>3.10.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Http/TixFactory.Http.Client/TixFactory.Http.Client.csproj
+++ b/Assemblies/Http/TixFactory.Http.Client/TixFactory.Http.Client.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
-		<PackageTags>http</PackageTags>
-	</PropertyGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\CookieJar\TixFactory.CookieJar\TixFactory.CookieJar.csproj" />
-		<ProjectReference Include="..\TixFactory.Http\TixFactory.Http.csproj" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net6</TargetFrameworks>
+    <PackageTags>http</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CookieJar\TixFactory.CookieJar\TixFactory.CookieJar.csproj" />
+    <ProjectReference Include="..\TixFactory.Http\TixFactory.Http.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
# What ⚠️ 

Following the [security notice](https://aka.ms/binaryformatter) for [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter?view=net-6.0), we will stop using it, immediately.

# Replacement :wrench:

Unfortunately, the replacement we have for it, is to serialize the cookies as JSON. And to to do that we need access to [CookieContainer.GetAllCookies](https://learn.microsoft.com/en-us/dotnet/api/system.net.cookiecontainer.getallcookies?view=net-6.0), which is only available starting in .NET 6.
See: https://stackoverflow.com/a/71987869/1663648

This means this NuGet package will no longer be available for .NET Standard, which is a breaking change. Such is life.