### PR TITLE
Fix Rabbit message deserialization bug

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.12.0</VersionPrefix>
+    <VersionPrefix>3.12.1</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">


### PR DESCRIPTION
Sometimes the message gets logged with some weird lookin characters. I'm going to try reading the `Body` property _once_ and see if that fixes anything.

And just in case it's a thread safety issue, I'm reading `DeliveryTag` in advance too.