### PR TITLE
Log + Dispose of bad messages by default

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.12.1</VersionPrefix>
+    <VersionPrefix>3.13.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Queueing/TixFactory.Queueing/Models/Configuration/IndividualQueueConfiguration.cs
+++ b/Assemblies/Queueing/TixFactory.Queueing/Models/Configuration/IndividualQueueConfiguration.cs
@@ -19,10 +19,10 @@ internal class IndividualQueueConfiguration
     ///
     /// When <c>false</c> the message will remain in the queue.
     /// </remarks>
-    public bool DisposeBadMessages { get; set; } = false;
+    public bool DisposeBadMessages { get; set; } = true;
 
     /// <summary>
     /// Whether or not to log a warning whenever a bad message is detected in the queue.
     /// </summary>
-    public bool LogBadMessages { get; set; } = false;
+    public bool LogBadMessages { get; set; } = true;
 }


### PR DESCRIPTION
If #63 fixes this bug, then we shouldn't have any harm in disposing of bad messages, and logging them.