### PR TITLE
Add re-queue option for Rabbit

### DIFF
--- a/Assemblies/Directory.Build.props
+++ b/Assemblies/Directory.Build.props
@@ -3,7 +3,7 @@
     <Company>Tix Factory</Company>
     <RepositoryUrl>https://github.com/tix-factory/nuget</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>3.13.0</VersionPrefix>
+    <VersionPrefix>3.14.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="TestsProperties" Condition="$(MSBuildProjectName.Contains('.Tests'))">

--- a/Assemblies/Queueing/TixFactory.Queueing/Enums/MessageProcessingResult.cs
+++ b/Assemblies/Queueing/TixFactory.Queueing/Enums/MessageProcessingResult.cs
@@ -35,4 +35,9 @@ public enum MessageProcessingResult
     /// Acts as a retry, but should not be returned directly.
     /// </remarks>
     UnhandledException = 4,
+
+    /// <summary>
+    /// Attempts to add the message back to the queue, and remove the original message.
+    /// </summary>
+    Requeue = 5,
 }


### PR DESCRIPTION
Enforce the queued messages end up in the back of the queue.